### PR TITLE
batch allocate empty items

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@ impl<T> Pool<T> {
         // If the pool is empty, we double the capacity and batch allocate
         // empty elements.
         if pool.free.is_empty() {
-            pool.capacity *= 2;
-            for _ in 0..(pool.capacity / 2) {
+            let capacity = pool.free.capacity();
+            pool.free.reserve(capacity);
+            for _ in 0..capacity {
                 let item = (*pool.creation)();
                 pool.free.push(item);
             }
@@ -51,7 +52,6 @@ impl<T> Clone for Pool<T> {
 }
 
 struct InternalPool<T> {
-    capacity: usize,
     free: Vec<T>,
     creation: Box<dyn Fn() -> T>,
     clearance: Box<dyn Fn(&mut T)>,
@@ -68,7 +68,6 @@ impl<T> InternalPool<T> {
             free.push(creation());
         }
         InternalPool {
-            capacity: cap,
             free,
             creation: Box::new(creation),
             clearance: Box::new(clearance),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,25 +7,30 @@ pub struct Pool<T> {
 }
 
 impl<T> Pool<T> {
-    pub fn new<C, D>(creation: C, clearance: D) -> Pool<T>
+    pub fn new<C, D>(cap: usize, creation: C, clearance: D) -> Pool<T>
     where
         C: Fn() -> T + 'static,
         D: Fn(&mut T) -> () + 'static,
     {
         Pool {
-            internal: Arc::new(Mutex::new(InternalPool::new(creation, clearance))),
+            internal: Arc::new(Mutex::new(InternalPool::new(cap, creation, clearance))),
         }
     }
 
     pub fn get<'a>(&'a self) -> ItemGuard<'a, T> {
         let mut pool = self.internal.lock().unwrap();
-        let item = if pool.free.is_empty() {
-            (*pool.creation)()
-        } else {
-            pool.free.pop().unwrap()
-        };
+        // If the pool is empty, we double the capacity and batch allocate
+        // empty elements.
+        if pool.free.is_empty() {
+            pool.capacity *= 2;
+            for _ in 0..(pool.capacity / 2) {
+                let item = (*pool.creation)();
+                pool.free.push(item);
+            }
+        }
+
         ItemGuard {
-            item: Some(item),
+            item: Some(pool.free.pop().unwrap()),
             pool: self,
         }
     }
@@ -46,19 +51,25 @@ impl<T> Clone for Pool<T> {
 }
 
 struct InternalPool<T> {
+    capacity: usize,
     free: Vec<T>,
     creation: Box<dyn Fn() -> T>,
     clearance: Box<dyn Fn(&mut T)>,
 }
 
 impl<T> InternalPool<T> {
-    pub fn new<C, D>(creation: C, clearance: D) -> Self
+    pub fn new<C, D>(cap: usize, creation: C, clearance: D) -> Self
     where
         C: Fn() -> T + 'static,
         D: Fn(&mut T) -> () + 'static,
     {
+        let mut free = Vec::with_capacity(cap);
+        for _ in 0..cap {
+            free.push(creation());
+        }
         InternalPool {
-            free: Vec::new(),
+            capacity: cap,
+            free,
             creation: Box::new(creation),
             clearance: Box::new(clearance),
         }
@@ -99,13 +110,7 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let pool = Pool::<Vec<u8>>::new(
-            || {
-                println!("Allocating new memory");
-                Vec::new()
-            },
-            |v| v.clear(),
-        );
+        let pool = Pool::<Vec<u8>>::new(1024, || Vec::new(), |v| v.clear());
         let mut item = pool.get();
         let mut _item2 = pool.get();
 
@@ -147,8 +152,8 @@ mod tests {
 
     #[bench]
     fn bench_remem(b: &mut Bencher) {
+        let pool = Pool::<Vec<usize>>::new(1024, || Vec::new(), |v| v.clear());
         b.iter(|| {
-            let pool = Pool::<Vec<usize>>::new(|| Vec::new(), |v| v.clear());
             run_benchmark!(pool.get());
         });
     }


### PR DESCRIPTION
Batch allocates empty items ahead of time; and batch grows them. Introduces a new argument "capacity" which sets the initial capacity. Unsure about the ergonomics of this, but think generally the right idea. Benches now seem to pull ahead consistently.

The only thing I'm confused about is that the regular vec test slows down. Unsure why tbf.

## Future directions

We should have a way to shrink the pool too if we consistently dip under 25% utilization we should halve the pool size.

## Results
__new__
```txt
test tests::bench_remem ... bench:   1,323,002 ns/iter (+/- 249,490)
test tests::bench_vec   ... bench:   1,419,678 ns/iter (+/- 10,898)
```

__before__
```txt
test tests::bench_remem ... bench:   1,316,925 ns/iter (+/- 201,543)
test tests::bench_vec   ... bench:   1,287,742 ns/iter (+/- 223,129)
```