### PR TITLE
Lock free

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2018"
 
 [dependencies]
 crossbeam-epoch = "0.8.0"
-crossbeam-utils = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ name = "mempool"
 version = "0.1.0"
 authors = ["Ryan Levick <ryan.levick@gmail.com>"]
 edition = "2018"
+
+[dependencies]
+crossbeam-epoch = "0.8.0"
+crossbeam-utils = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mempool"
+name = "remem"
 version = "0.1.0"
 authors = ["Ryan Levick <ryan.levick@gmail.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -5,23 +5,20 @@ Utility for reusing pieces of memory
 ## Usage
 
 ``` rust
-        let pool = Pool::<Vec<u8>>::new(
-            || Vec::new(),
-            |v| v.clear(),
-        );
-        let mut item = pool.get();
+let pool = Pool::<Vec<u8>>::new(|| Vec::new());
+let mut item = pool.get();
 
-        item.push(1);
-        item.push(2);
-        item.push(3);
+item.push(1);
+item.push(2);
+item.push(3);
 
-        drop(item);
+drop(item);
 
-        // item's memory can now be reused
+// item's memory can now be reused
 
-        let mut item = pool.get();
+let mut item = pool.get();
 
-        item.push(1);
-        item.push(2);
-        item.push(3);
+item.push(1);
+item.push(2);
+item.push(3);
 ```

--- a/benches/pool.rs
+++ b/benches/pool.rs
@@ -1,0 +1,54 @@
+#![feature(test)]
+
+extern crate test;
+
+use remem::Pool;
+use std::thread;
+use test::Bencher;
+
+#[bench]
+fn create(b: &mut Bencher) {
+    b.iter(|| Pool::<Vec<()>>::new(|| Vec::new(), |v| v.clear()));
+}
+
+#[bench]
+fn contention(b: &mut Bencher) {
+    b.iter(|| run(10, 1000));
+}
+
+#[bench]
+fn no_contention(b: &mut Bencher) {
+    b.iter(|| run(1, 10000));
+}
+
+fn run(thread: usize, iter: usize) {
+    let p = Pool::<Vec<usize>>::new(|| vec![], |v| v.clear());
+    let mut threads = Vec::new();
+
+    for _ in 0..thread {
+        let p = p.clone();
+        threads.push(thread::spawn(move || {
+            for _ in 0..iter {
+                let mut v = p.get();
+                v.push(1);
+            }
+        }));
+    }
+
+    for t in threads {
+        t.join();
+    }
+}
+
+// #[bench]
+// fn bench_remem(b: &mut Bencher) {
+//     let pool = Pool::<Vec<usize>>::new(1024, || Vec::new(), |v| v.clear());
+//     b.iter(|| {
+//         run_benchmark!(|| pool.get());
+//     });
+// }
+
+// #[bench]
+// fn bench_vec(b: &mut Bencher) {
+//     b.iter(|| run_benchmark!(|| Vec::new()));
+// }

--- a/benches/pool.rs
+++ b/benches/pool.rs
@@ -12,7 +12,7 @@ mod remem {
 
     #[bench]
     fn create(b: &mut Bencher) {
-        b.iter(|| Pool::<Vec<usize>>::new(|| vec![0; CAPACITY], |v| v.clear()));
+        b.iter(|| Pool::<Vec<usize>>::new(|| vec![0; CAPACITY]));
     }
 
     #[bench]
@@ -26,7 +26,7 @@ mod remem {
     }
 
     fn run(thread: usize, iter: usize) {
-        let p = Pool::<Vec<usize>>::new(|| vec![0; CAPACITY], |_| ());
+        let p = Pool::<Vec<usize>>::new(|| vec![0; CAPACITY]);
         let mut threads = Vec::new();
 
         for _ in 0..thread {

--- a/benches/pool.rs
+++ b/benches/pool.rs
@@ -26,7 +26,7 @@ mod remem {
     }
 
     fn run(thread: usize, iter: usize) {
-        let p = Pool::<Vec<usize>>::new(|| vec![0; CAPACITY]);
+        let p = Pool::new(|| vec![0usize; CAPACITY]);
         let mut threads = Vec::new();
 
         for _ in 0..thread {
@@ -73,7 +73,7 @@ mod vec {
         for _ in 0..thread {
             threads.push(thread::spawn(move || {
                 for _ in 0..iter {
-                    let mut v: Vec<usize> = vec![0; CAPACITY];
+                    let mut v = vec![0usize; CAPACITY];
                     v[0] = 1;
                     v[CAPACITY / 4] = 1;
                     v[CAPACITY / 2] = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,22 +7,18 @@ mod treiber_stack;
 
 struct Internal<T> {
     free: Stack<T>,
-    create: Box<dyn Fn() -> T>,
-    clear: Box<dyn Fn(&mut T)>,
+    create: Box<dyn Fn() -> T + Send + Sync>,
+    clear: Box<dyn Fn(&mut T) + Send + Sync>,
 }
 
 impl<T> Internal<T> {
-    pub fn new<C, D>(cap: usize, create: C, clear: D) -> Self
+    pub fn new<C, D>(create: C, clear: D) -> Self
     where
-        C: Fn() -> T + 'static,
-        D: Fn(&mut T) -> () + 'static,
+        C: Fn() -> T + Send + Sync + 'static,
+        D: Fn(&mut T) -> () + Send + Sync + 'static,
     {
-        let free = Stack::new();
-        for _ in 0..cap {
-            free.push(create());
-        }
         Internal {
-            free,
+            free: Stack::new(),
             create: Box::new(create),
             clear: Box::new(clear),
         }
@@ -35,19 +31,19 @@ pub struct Pool<T> {
 }
 
 impl<T> Pool<T> {
-    pub fn new<C, D>(cap: usize, create: C, clear: D) -> Pool<T>
+    pub fn new<C, D>(create: C, clear: D) -> Pool<T>
     where
-        C: Fn() -> T + 'static,
-        D: Fn(&mut T) -> () + 'static,
+        C: Fn() -> T + Send + Sync + 'static,
+        D: Fn(&mut T) -> () + Send + Sync + 'static,
     {
         Pool {
-            internal: Arc::new(Internal::new(cap, create, clear)),
+            internal: Arc::new(Internal::new(create, clear)),
         }
     }
 
     pub fn get<'a>(&'a self) -> ItemGuard<'a, T> {
         let pool = &self.internal;
-        let item = if pool.free.is_empty() {
+        let item = if dbg!(pool.free.is_empty()) {
             (*pool.create)()
         } else {
             pool.free.pop().unwrap()
@@ -96,77 +92,5 @@ impl<'a, T> std::ops::Deref for ItemGuard<'a, T> {
 impl<'a, T> std::ops::DerefMut for ItemGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.item.as_mut().unwrap()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    extern crate test;
-    use test::Bencher;
-
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let pool = Pool::<Vec<u8>>::new(
-            1024,
-            || {
-                println!("Allocating new memory");
-                Vec::new()
-            },
-            |v| v.clear(),
-        );
-        let mut item = pool.get();
-        let mut _item2 = pool.get();
-
-        item.push(1);
-        item.push(2);
-        item.push(3);
-
-        drop(item);
-
-        let mut item = pool.get();
-
-        item.push(1);
-        item.push(2);
-        item.push(3);
-    }
-
-    const ORIGINAL_SIZE: usize = 10;
-    const ITERATIONS: usize = 10;
-
-    macro_rules! run_benchmark {
-        ($create_item:expr) => {{
-            for _ in 0..1000 {
-                let mut item = $create_item();
-
-                for n in 0..ORIGINAL_SIZE {
-                    item.push(n);
-                }
-
-                drop(item);
-
-                for n in 0..ITERATIONS {
-                    let mut item = $create_item();
-
-                    for n in 0..(ITERATIONS - n) {
-                        item.push(n);
-                    }
-                }
-            }
-        }};
-    }
-
-    #[bench]
-    fn bench_remem(b: &mut Bencher) {
-        let pool = Pool::<Vec<usize>>::new(1024, || Vec::new(), |v| v.clear());
-        b.iter(|| {
-            run_benchmark!(|| pool.get());
-        });
-    }
-
-    #[bench]
-    fn bench_vec(b: &mut Bencher) {
-        b.iter(|| run_benchmark!(|| Vec::new()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use treiber_stack::TreiberStack as Stack;
 
@@ -61,7 +62,7 @@ impl<T> Pool<T> {
     }
 
     /// Store an item back inside the pool.
-    fn reintroduce(&self, mut item: T) {
+    fn push(&self, mut item: T) {
         (*self.internal.clear)(&mut item);
         self.internal.stack.push(item);
     }
@@ -83,11 +84,11 @@ pub struct ItemGuard<'a, T> {
 
 impl<'a, T> Drop for ItemGuard<'a, T> {
     fn drop(&mut self) {
-        self.pool.reintroduce(self.item.take().unwrap())
+        self.pool.push(self.item.take().unwrap())
     }
 }
 
-impl<'a, T> std::ops::Deref for ItemGuard<'a, T> {
+impl<'a, T> Deref for ItemGuard<'a, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -95,7 +96,7 @@ impl<'a, T> std::ops::Deref for ItemGuard<'a, T> {
     }
 }
 
-impl<'a, T> std::ops::DerefMut for ItemGuard<'a, T> {
+impl<'a, T> DerefMut for ItemGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.item.as_mut().unwrap()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,10 @@ impl<T> Pool<T> {
     }
 
     pub fn get<'a>(&'a self) -> ItemGuard<'a, T> {
-        let item = self.internal.stack.pop().unwrap_or_else(|| (*self.internal.create)());
+        let pool = &self.internal;
+        let item = pool.stack.pop();
         ItemGuard {
-            item: Some(item),
+            item: Some(item.unwrap_or_else(|| (*self.internal.create)())),
             pool: self,
         }
     }

--- a/src/treiber_stack.rs
+++ b/src/treiber_stack.rs
@@ -1,0 +1,93 @@
+//! Treiber stack, copied from crossbeam's examples directory.
+//!
+//! https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-epoch/examples/treiber_stack.rs
+
+use std::mem::ManuallyDrop;
+use std::ptr;
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+
+use crossbeam_epoch::{Atomic, Owned};
+use crossbeam_utils::thread::scope;
+
+/// Treiber's lock-free stack.
+///
+/// Usable with any number of producers and consumers.
+#[derive(Debug)]
+pub struct TreiberStack<T> {
+    head: Atomic<Node<T>>,
+}
+
+#[derive(Debug)]
+pub(super) struct Node<T> {
+    data: ManuallyDrop<T>,
+    next: Atomic<Node<T>>,
+}
+
+impl<T> TreiberStack<T> {
+    /// Creates a new, empty stack.
+    pub(super) fn new() -> TreiberStack<T> {
+        TreiberStack {
+            head: Atomic::null(),
+        }
+    }
+
+    /// Pushes a value on top of the stack.
+    pub(super) fn push(&self, t: T) {
+        let mut n = Owned::new(Node {
+            data: ManuallyDrop::new(t),
+            next: Atomic::null(),
+        });
+
+        let guard = crossbeam_epoch::pin();
+
+        loop {
+            let head = self.head.load(Relaxed, &guard);
+            n.next.store(head, Relaxed);
+
+            match self.head.compare_and_set(head, n, Release, &guard) {
+                Ok(_) => break,
+                Err(e) => n = e.new,
+            }
+        }
+    }
+
+    /// Attempts to pop the top element from the stack.
+    ///
+    /// Returns `None` if the stack is empty.
+    pub(super) fn pop(&self) -> Option<T> {
+        let guard = crossbeam_epoch::pin();
+        loop {
+            let head = self.head.load(Acquire, &guard);
+
+            match unsafe { head.as_ref() } {
+                Some(h) => {
+                    let next = h.next.load(Relaxed, &guard);
+
+                    if self
+                        .head
+                        .compare_and_set(head, next, Release, &guard)
+                        .is_ok()
+                    {
+                        unsafe {
+                            guard.defer_destroy(head);
+                            return Some(ManuallyDrop::into_inner(ptr::read(&(*h).data)));
+                        }
+                    }
+                }
+                None => return None,
+            }
+        }
+    }
+
+    /// Returns `true` if the stack is empty.
+    pub(super) fn is_empty(&self) -> bool {
+        let guard = crossbeam_epoch::pin();
+        self.head.load(Acquire, &guard).is_null()
+    }
+}
+
+impl<T> Drop for TreiberStack<T> {
+    fn drop(&mut self) {
+        while self.pop().is_some() {}
+    }
+}

--- a/src/treiber_stack.rs
+++ b/src/treiber_stack.rs
@@ -2,14 +2,11 @@
 //!
 //! https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-epoch/examples/treiber_stack.rs
 
-#![allow(unused)]
-
 use std::mem::ManuallyDrop;
 use std::ptr;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 use crossbeam_epoch::{Atomic, Owned};
-use crossbeam_utils::thread::scope;
 
 /// Treiber's lock-free stack.
 ///
@@ -79,12 +76,6 @@ impl<T> TreiberStack<T> {
                 None => return None,
             }
         }
-    }
-
-    /// Returns `true` if the stack is empty.
-    pub(super) fn is_empty(&self) -> bool {
-        let guard = crossbeam_epoch::pin();
-        self.head.load(Acquire, &guard).is_null()
     }
 }
 

--- a/src/treiber_stack.rs
+++ b/src/treiber_stack.rs
@@ -2,6 +2,8 @@
 //!
 //! https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-epoch/examples/treiber_stack.rs
 
+#![allow(unused)]
+
 use std::mem::ManuallyDrop;
 use std::ptr;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,7 +2,7 @@ use remem::Pool;
 
 #[test]
 fn it_works() {
-    let pool = Pool::<Vec<u8>>::new(|| Vec::new(), |v| v.clear());
+    let pool = Pool::<Vec<u8>>::new(|| Vec::new());
     let mut item = pool.get();
     item.push(1);
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,11 @@
+use remem::Pool;
+
+#[test]
+fn it_works() {
+    let pool = Pool::<Vec<u8>>::new(|| Vec::new(), |v| v.clear());
+    let mut item = pool.get();
+    item.push(1);
+
+    let mut item = pool.get();
+    item.push(1);
+}


### PR DESCRIPTION
Moves us away from the mutex, and uses a treiber stack instead. This version does quite well compared to the vec test, and *especially* at higher buffer sizes.

The thing I'm kind of wondering about now though is whether the `clear` closure is useful at all; since `Drop` already serves that purpose, and crates like [zeroize](https://docs.rs/zeroize/1.0.0/zeroize/) already provide zeroing of memory on drop. In the bench we're using an empty closure instead, and it feels like it should probably just go.

Thanks!

## Benches
Tested with 1000 iterations of creating and writing to 4kb buffers. "contention" is with 10 threads operating in parallel.

```txt
running 6 tests
test remem::contention    ... bench:   1,292,950 ns/iter (+/- 59,003)
test remem::create        ... bench:          43 ns/iter (+/- 1)
test remem::no_contention ... bench:     126,991 ns/iter (+/- 4,942)
test vec::contention      ... bench:   4,065,753 ns/iter (+/- 664,198)
test vec::create          ... bench:         298 ns/iter (+/- 20)
test vec::no_contention   ... bench:     652,184 ns/iter (+/- 57,683)
test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured; 0 filtered out
```