### PR TITLE
Remove lifetime from `ItemGuard`

### DIFF
--- a/benches/pool.rs
+++ b/benches/pool.rs
@@ -25,6 +25,17 @@ mod remem {
         b.iter(|| run(1, 1000));
     }
 
+    #[bench]
+    fn get(b: &mut Bencher) {
+        b.iter(|| {
+            let p = Pool::new(|| vec![0u8; CAPACITY]);
+
+            for _ in 0..1000 {
+                black_box(p.get());
+            }
+        });
+    }
+
     fn run(thread: usize, iter: usize) {
         let p = Pool::new(|| vec![0u8; CAPACITY]);
         let mut threads = Vec::new();


### PR DESCRIPTION
Since inner object is `Arc`, lifetime is not needed.

This enables more flexible usage, for example sending an `ItemGuard<T>` via a channel.